### PR TITLE
Remove unnecessary settings for loading of static assets

### DIFF
--- a/lib/katgut/engine.rb
+++ b/lib/katgut/engine.rb
@@ -6,9 +6,5 @@ module Katgut
       g.test_framework :rspec, fixture: false
       g.fixture_replacement :factory_girl, dir: "spec/factories"
     end
-
-    initializer "static assets" do |app|
-      app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public")
-    end
   end
 end

--- a/lib/katgut/version.rb
+++ b/lib/katgut/version.rb
@@ -1,3 +1,3 @@
 module Katgut
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
## Problem
- Initializer for static assets brokes 'rake assets:precompile' in the host app, when the app is set not to serve static assets.
  - http://stackoverflow.com/questions/34287038/why-actiondispatchstatic-is-removed-from-the-middleware-stack-in-production
## Solution
- Remove the initializer
- The lines were added for static assets, which only used in test app. But actually, it works without the settings!
