### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Suppose the engine is mounted to your app in this way:
 ```ruby
 # config/routes.rb
 Rails.application.routes.draw do
-  mount Katgut::Engine => "/katgut"
+  mount Katgut::Engine => "/katgut", as: 'katgut'
 end
 ```
 


### PR DESCRIPTION
If you would like to call `katgut.rule_path('xxx')`, you should add setting on `routes.rb` like this.

Can you check it? @manemone 
