### PR TITLE
[IR] Change s.required_ruby_version '~> 2.3' to '>= 2.3'

### DIFF
--- a/katgut.gemspec
+++ b/katgut.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,public}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.required_ruby_version = '~> 2.3'
+  s.required_ruby_version = '>= 2.3'
 
   s.add_dependency "rails", '>= 4.2.6'
 


### PR DESCRIPTION
### Background
In the process of upgrading our private repository using katgut, we needed to increase the version of Ruby available.


### TODO
Change s.required_ruby_version specification from `'~> 2.3'` to `'>= 2.3'`


### NOT TODO
The range of acceptable Ruby versions has been changed, but currently no errors have been observed due to this change. Therefore, we will not prepare a new katgut version.